### PR TITLE
feat: link overdue card to inbox filter

### DIFF
--- a/app/inbox/page.tsx
+++ b/app/inbox/page.tsx
@@ -82,7 +82,15 @@ const InboxSection = ({
   </Card>
 );
 
-export default async function InboxPage() {
+type inboxPageProps = {
+  searchParams?: Promise<{
+    filter?: string;
+  }>;
+};
+
+export default async function InboxPage({ searchParams }: inboxPageProps) {
+  const params = (await searchParams) ?? {};
+  const filter = params.filter;
   const { listInbox } = await getUseCases();
   const { overdue, today, upcoming } = await listInbox();
 
@@ -96,27 +104,39 @@ export default async function InboxPage() {
       </header>
 
       <div className="grid gap-4">
-        <InboxSection
-          title="Vencidas"
-          emptyLabel="No tienes acciones vencidas."
-          items={overdue}
-          onMarkDone={markDoneAction}
-          onReschedule={rescheduleAction}
-        />
-        <InboxSection
-          title="Hoy"
-          emptyLabel="Sin acciones para hoy."
-          items={today}
-          onMarkDone={markDoneAction}
-          onReschedule={rescheduleAction}
-        />
-        <InboxSection
-          title="Proximas"
-          emptyLabel="Sin acciones proximas."
-          items={upcoming}
-          onMarkDone={markDoneAction}
-          onReschedule={rescheduleAction}
-        />
+        {filter === "overdue" ? (
+          <InboxSection
+            title="Vencidas"
+            emptyLabel="No tienes acciones vencidas."
+            items={overdue}
+            onMarkDone={markDoneAction}
+            onReschedule={rescheduleAction}
+          />
+        ) : (
+          <>
+            <InboxSection
+              title="Vencidas"
+              emptyLabel="No tienes acciones vencidas."
+              items={overdue}
+              onMarkDone={markDoneAction}
+              onReschedule={rescheduleAction}
+            />
+            <InboxSection
+              title="Hoy"
+              emptyLabel="Sin acciones para hoy."
+              items={today}
+              onMarkDone={markDoneAction}
+              onReschedule={rescheduleAction}
+            />
+            <InboxSection
+              title="Proximas"
+              emptyLabel="Sin acciones proximas."
+              items={upcoming}
+              onMarkDone={markDoneAction}
+              onReschedule={rescheduleAction}
+            />
+          </>
+        )}
       </div>
     </div>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
@@ -69,12 +70,17 @@ export default async function Home() {
             <p className="text-2xl font-semibold">{activeInterviews}</p>
           </CardContent>
         </Card>
-        <Card className="py-4">
-          <CardContent className="space-y-1">
-            <p className="text-xs text-muted-foreground">Acciones vencidas</p>
-            <p className="text-2xl font-semibold">{overdueCount}</p>
-          </CardContent>
-        </Card>
+        <Link
+          href="/inbox?filter=overdue"
+          className="block rounded-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        >
+          <Card className="py-4">
+            <CardContent className="space-y-1">
+              <p className="text-xs text-muted-foreground">Acciones vencidas</p>
+              <p className="text-2xl font-semibold">{overdueCount}</p>
+            </CardContent>
+          </Card>
+        </Link>
         <Card className="py-4">
           <CardContent className="space-y-1">
             <p className="text-xs text-muted-foreground">


### PR DESCRIPTION
## Summary
- link the Home "Acciones vencidas" card to the overdue inbox filter
- support /inbox?filter=overdue rendering only the overdue section

Closes #1
