### PR TITLE
feat: job triage foundations

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # ROADMAP – Workx
 
-Status: Phase 0 complete; current work is post-Phase 0 (Phase 3 planned).
+Status: Phase 0 complete; current work is post-Phase 0 (Phase 3 in progress).
 
 ## Phase 0 – Execution UI (Portfolio Core) ✅
 
@@ -99,7 +99,7 @@ Status: Phase 0 complete; current work is post-Phase 0 (Phase 3 planned).
 
 ---
 
-## Phase 3 – Job Triage & Ranking (Agent-Assisted) 🟡 Planned
+## Phase 3 – Job Triage & Ranking (Agent-Assisted) 🟡 In Progress
 
 **Goal:** Reduce decision fatigue by filtering and prioritizing jobs using the user’s real profile.
 

--- a/app/api/triage/jobs/route.ts
+++ b/app/api/triage/jobs/route.ts
@@ -1,0 +1,42 @@
+import { NextResponse } from "next/server";
+import { revalidatePath } from "next/cache";
+import { getUseCases } from "@/src/composition/usecases";
+
+type triageMode = "new" | "recent";
+
+const toMode = (value: unknown): triageMode =>
+  value === "recent" ? "recent" : "new";
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => ({}));
+  const mode = toMode(body?.mode);
+  const days =
+    typeof body?.days === "number" && body.days > 0 ? body.days : 14;
+
+  try {
+    const { triageJobs } = await getUseCases();
+    const result = await triageJobs({ mode, days });
+    if (!result.ok) {
+      return NextResponse.json(
+        { ok: false, error: result.error.message },
+        { status: 500 }
+      );
+    }
+
+    revalidatePath("/jobs");
+    revalidatePath("/");
+
+    return NextResponse.json({ ok: true, ...result.value });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "No pudimos analizar trabajos.",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/jobs/TriageControls.tsx
+++ b/app/jobs/TriageControls.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/ui/use-toast";
+
+type triageMode = "new" | "recent";
+
+export default function TriageControls() {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [pendingMode, setPendingMode] = useState<triageMode | null>(null);
+
+  const runTriage = async (mode: triageMode) => {
+    if (pendingMode) return;
+    setPendingMode(mode);
+    try {
+      const response = await fetch("/api/triage/jobs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ mode, days: 14 }),
+      });
+      const payload = (await response.json()) as {
+        ok: boolean;
+        processed?: number;
+        triaged?: number;
+        skipped?: number;
+        error?: string;
+      };
+      if (!response.ok || !payload.ok) {
+        throw new Error(payload.error ?? "No pudimos analizar trabajos.");
+      }
+      toast({
+        title: `Analisis listo: ${payload.triaged ?? 0} actualizados.`,
+        variant: "success",
+      });
+      router.refresh();
+    } catch (error) {
+      toast({
+        title:
+          error instanceof Error
+            ? error.message
+            : "No pudimos analizar trabajos.",
+        variant: "destructive",
+      });
+    } finally {
+      setPendingMode(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={pendingMode !== null}
+        onClick={() => runTriage("new")}
+      >
+        {pendingMode === "new" ? "Analizando..." : "Analizar nuevos"}
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        disabled={pendingMode !== null}
+        onClick={() => runTriage("recent")}
+      >
+        {pendingMode === "recent"
+          ? "Analizando..."
+          : "Re-analizar recientes"}
+      </Button>
+    </div>
+  );
+}

--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -11,12 +11,14 @@ import {
 import { saveJobAction } from "@/app/jobs/actions";
 import { getUseCases } from "@/src/composition/usecases";
 import JobTable from "@/src/components/JobTable";
+import TriageControls from "@/app/jobs/TriageControls";
 
 type jobsPageProps = {
   searchParams?: Promise<{
     q?: string;
     source?: string;
     seniority?: string;
+    triage?: string;
   }>;
 };
 
@@ -26,14 +28,22 @@ export default async function JobsPage({ searchParams }: jobsPageProps) {
   const search = params.q?.trim() ?? "";
   const rawSource = params.source;
   const rawSeniority = params.seniority;
+  const rawTriage = params.triage;
   const source = rawSource && rawSource !== "all" ? rawSource : undefined;
   const seniority =
     rawSeniority && rawSeniority !== "all" ? rawSeniority : undefined;
+  const triageStatus =
+    rawTriage === "shortlist" ||
+    rawTriage === "maybe" ||
+    rawTriage === "reject"
+      ? rawTriage
+      : undefined;
 
   const jobs = await listJobs({
     search: search || undefined,
     source,
     seniority,
+    triageStatus,
   });
   const allJobs = await listJobs();
   const applications = await listApplications();
@@ -109,6 +119,22 @@ export default async function JobsPage({ searchParams }: jobsPageProps) {
                 </SelectContent>
               </Select>
             </div>
+            <div className="min-w-[160px]">
+              <label className="text-xs text-muted-foreground" htmlFor="triage">
+                Triage
+              </label>
+              <Select name="triage" defaultValue={rawTriage ?? "all"}>
+                <SelectTrigger id="triage" className="mt-1 w-full">
+                  <SelectValue placeholder="Todos" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="all">Todos</SelectItem>
+                  <SelectItem value="shortlist">Seleccionados</SelectItem>
+                  <SelectItem value="maybe">Quizas</SelectItem>
+                  <SelectItem value="reject">Rechazados</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
             <div className="flex items-center gap-2">
               <Button type="submit" variant="outline" size="sm">
                 Filtrar
@@ -118,6 +144,7 @@ export default async function JobsPage({ searchParams }: jobsPageProps) {
               </Button>
             </div>
           </form>
+          <TriageControls />
         </div>
 
         <JobTable

--- a/src/adapters/memory/seed.ts
+++ b/src/adapters/memory/seed.ts
@@ -89,6 +89,10 @@ const seedJobsBase = (data: {
   tags: string[];
   description?: string | null;
   publishedAt?: isoDateTime | null;
+  triageStatus?: "shortlist" | "maybe" | "reject" | null;
+  triageReasons?: string[] | null;
+  triagedAt?: isoDateTime | null;
+  triageProvider?: "ollama" | "openai" | null;
   createdOffsetDays: number;
   updatedOffsetDays: number;
 }): job => ({
@@ -102,6 +106,10 @@ const seedJobsBase = (data: {
   seniority: data.seniority,
   tags: data.tags,
   description: data.description ?? null,
+  triageStatus: data.triageStatus ?? null,
+  triageReasons: data.triageReasons ?? null,
+  triagedAt: data.triagedAt ?? null,
+  triageProvider: data.triageProvider ?? null,
   publishedAt: data.publishedAt ?? null,
   createdAt: toIso(addDays(seedToday, data.createdOffsetDays)),
   updatedAt: toIso(addDays(seedToday, data.updatedOffsetDays)),

--- a/src/adapters/triage/job-triage.ts
+++ b/src/adapters/triage/job-triage.ts
@@ -1,0 +1,199 @@
+import { job } from "@/src/domain/entities/job";
+import { userProfile } from "@/src/domain/entities/user-profile";
+import { triageProvider } from "@/src/domain/types/triage-provider";
+import { triageStatus } from "@/src/domain/types/triage-status";
+import { jobTriageDecision, jobTriagePort } from "@/src/ports/job-triage";
+
+type triagePayload = {
+  decision?: string;
+  status?: string;
+  reasons?: unknown;
+};
+
+const trimText = (value: string, maxLength = 2000) =>
+  value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
+
+const buildProfileText = (profile: userProfile) => {
+  const parts = [
+    `must_have: ${profile.mustHaveKeywords.join(", ")}`,
+    `hard_no: ${profile.hardNoKeywords.join(", ")}`,
+    `preferred: ${profile.preferredKeywords.join(", ")}`,
+    `excluded: ${profile.excludedKeywords.join(", ")}`,
+  ];
+  if (profile.notes) {
+    parts.push(`notes: ${profile.notes}`);
+  }
+  return parts.join("\n");
+};
+
+const buildJobText = (jobRecord: job) => {
+  const description = jobRecord.description
+    ? trimText(jobRecord.description)
+    : "none";
+  return [
+    `role: ${jobRecord.role}`,
+    `company: ${jobRecord.company}`,
+    `location: ${jobRecord.location}`,
+    `seniority: ${jobRecord.seniority}`,
+    `tags: ${jobRecord.tags.join(", ")}`,
+    `description: ${description}`,
+  ].join("\n");
+};
+
+const parseDecision = (value: string | undefined | null): triageStatus | null => {
+  if (!value) return null;
+  const normalized = value.toLowerCase().trim();
+  if (normalized === "shortlist") return "shortlist";
+  if (normalized === "maybe") return "maybe";
+  if (normalized === "reject") return "reject";
+  return null;
+};
+
+const normalizeReasons = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => (typeof item === "string" ? item.trim() : ""))
+      .filter(Boolean);
+  }
+  return [];
+};
+
+const extractJson = (text: string): triagePayload | null => {
+  const match = text.match(/\{[\s\S]*\}/);
+  if (!match) return null;
+  try {
+    return JSON.parse(match[0]) as triagePayload;
+  } catch {
+    return null;
+  }
+};
+
+const toDecision = (
+  payload: triagePayload | null,
+  provider: triageProvider
+): jobTriageDecision | null => {
+  if (!payload) return null;
+  const decision = parseDecision(payload.decision ?? payload.status);
+  if (!decision) return null;
+  const reasons = normalizeReasons(payload.reasons);
+  return {
+    status: decision,
+    reasons,
+    provider,
+  };
+};
+
+const buildCoarsePrompt = (jobRecord: job, profile: userProfile) => `You are a job triage assistant.
+Return JSON only in the form:
+{"decision":"shortlist|maybe|reject","reasons":["reason 1","reason 2"]}
+
+User profile:
+${buildProfileText(profile)}
+
+Job:
+${buildJobText(jobRecord)}
+`;
+
+const buildDisambiguationPrompt = (
+  jobRecord: job,
+  profile: userProfile,
+  previous: jobTriageDecision
+) => `You are a job triage assistant.
+Return JSON only in the form:
+{"decision":"shortlist|maybe|reject","reasons":["reason 1","reason 2"]}
+
+Previous decision: ${previous.status}
+
+User profile:
+${buildProfileText(profile)}
+
+Job:
+${buildJobText(jobRecord)}
+`;
+
+const fetchOllama = async (
+  jobRecord: job,
+  profile: userProfile
+): Promise<jobTriageDecision | null> => {
+  const baseUrl = process.env.OLLAMA_BASE_URL?.trim() ?? "";
+  const model = process.env.OLLAMA_MODEL?.trim() ?? "";
+  if (!baseUrl || !model) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(
+      `${baseUrl.replace(/\\/$/, "")}/api/generate`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model,
+          prompt: buildCoarsePrompt(jobRecord, profile),
+          stream: false,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as { response?: string };
+    const payload = data.response ? extractJson(data.response) : null;
+    return toDecision(payload, "ollama");
+  } catch {
+    return null;
+  }
+};
+
+const fetchOpenAI = async (
+  jobRecord: job,
+  profile: userProfile,
+  previous: jobTriageDecision
+): Promise<jobTriageDecision | null> => {
+  const apiKey = process.env.OPENAI_API_KEY?.trim() ?? "";
+  const model = process.env.OPENAI_MODEL?.trim() ?? "";
+  if (!apiKey || !model) {
+    return null;
+  }
+
+  try {
+    const response = await fetch("https://api.openai.com/v1/responses", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model,
+        input: buildDisambiguationPrompt(jobRecord, profile, previous),
+        response_format: { type: "json_object" },
+      }),
+    });
+
+    if (!response.ok) {
+      return null;
+    }
+
+    const data = (await response.json()) as {
+      output_text?: string;
+      output?: { content?: { text?: string }[] }[];
+    };
+    const text =
+      data.output_text ??
+      data.output?.[0]?.content?.[0]?.text ??
+      "";
+    const payload = text ? extractJson(text) : null;
+    return toDecision(payload, "openai");
+  } catch {
+    return null;
+  }
+};
+
+export const createJobTriageAdapter = (): jobTriagePort => ({
+  coarse: async ({ job: jobRecord, profile }) =>
+    fetchOllama(jobRecord, profile),
+  disambiguate: async ({ job: jobRecord, profile, previous }) =>
+    fetchOpenAI(jobRecord, profile, previous),
+});

--- a/src/components/JobTable.tsx
+++ b/src/components/JobTable.tsx
@@ -33,6 +33,13 @@ const stopRowClick = (event: MouseEvent | KeyboardEvent) => {
   event.stopPropagation();
 };
 
+const triageLabel = (status: job["triageStatus"]) => {
+  if (status === "shortlist") return "Seleccionado";
+  if (status === "maybe") return "Quizas";
+  if (status === "reject") return "Rechazado";
+  return null;
+};
+
 export default function JobTable({
   jobs,
   savedJobIds,
@@ -87,20 +94,36 @@ export default function JobTable({
               }}
             >
               <TableCell className="font-medium">
-                {variant === "list" && job.sourceUrl ? (
-                  <a
-                    href={job.sourceUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="underline-offset-4 hover:underline"
-                    onClick={stopRowClick}
-                    onKeyDown={stopRowClick}
-                  >
-                    {job.role}
-                  </a>
-                ) : (
-                  job.role
-                )}
+                <div className="space-y-1">
+                  <div>
+                    {variant === "list" && job.sourceUrl ? (
+                      <a
+                        href={job.sourceUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="underline-offset-4 hover:underline"
+                        onClick={stopRowClick}
+                        onKeyDown={stopRowClick}
+                      >
+                        {job.role}
+                      </a>
+                    ) : (
+                      job.role
+                    )}
+                  </div>
+                  {(job.triageStatus || job.triageReasons?.length) && (
+                    <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+                      {triageLabel(job.triageStatus) && (
+                        <Badge variant="outline">
+                          {triageLabel(job.triageStatus)}
+                        </Badge>
+                      )}
+                      {job.triageReasons?.slice(0, 2).map((reason) => (
+                        <span key={reason}>{reason}</span>
+                      ))}
+                    </div>
+                  )}
+                </div>
               </TableCell>
               <TableCell>{job.company}</TableCell>
               {variant === "list" && (

--- a/src/composition/repositories.ts
+++ b/src/composition/repositories.ts
@@ -8,6 +8,7 @@ import {
 } from "@/src/adapters/memory/seed";
 import { memoryStore } from "@/src/adapters/memory/store";
 import { createRemotiveJobSource } from "@/src/adapters/remotive/job-source";
+import { createJobTriageAdapter } from "@/src/adapters/triage/job-triage";
 
 type globalStore = { __workxMemoryStore?: memoryStore };
 
@@ -34,6 +35,7 @@ const createMemoryRepositories = () => {
     applicationLogRepository: createMemoryApplicationLogRepository(store),
     jobRepository: createMemoryJobRepository(store),
     jobSource: createRemotiveJobSource(),
+    jobTriage: createJobTriageAdapter(),
   };
 };
 
@@ -55,5 +57,6 @@ export async function getRepositories() {
     applicationLogRepository: createSupabaseApplicationLogRepository(),
     jobRepository: createSupabaseJobRepository(),
     jobSource: createRemotiveJobSource(),
+    jobTriage: createJobTriageAdapter(),
   };
 }

--- a/src/composition/usecases.ts
+++ b/src/composition/usecases.ts
@@ -8,6 +8,8 @@ import { createListJobsUseCase } from "@/src/services/usecases/list-jobs";
 import { updateApplicationUseCase } from "@/src/services/usecases/update-application";
 import { createIngestJobsUseCase } from "@/src/services/usecases/ingest-jobs";
 import { createArchiveApplicationUseCase } from "@/src/services/usecases/archive-application";
+import { createTriageJobsUseCase } from "@/src/services/usecases/triage-jobs";
+import { defaultUserProfile } from "@/src/composition/user-profile";
 
 let _usecases: Awaited<ReturnType<typeof buildUseCases>> | null = null;
 
@@ -27,6 +29,11 @@ async function buildUseCases() {
     ingestJobs: createIngestJobsUseCase({
       jobSource: repositories.jobSource,
       jobRepository: repositories.jobRepository,
+    }),
+    triageJobs: createTriageJobsUseCase({
+      jobRepository: repositories.jobRepository,
+      jobTriage: repositories.jobTriage,
+      profile: defaultUserProfile,
     }),
     createApplicationFromJob: createApplicationFromJobUseCase({
       applicationRepository: repositories.applicationRepository,

--- a/src/composition/user-profile.ts
+++ b/src/composition/user-profile.ts
@@ -1,0 +1,9 @@
+import { userProfile } from "@/src/domain/entities/user-profile";
+
+export const defaultUserProfile: userProfile = {
+  mustHaveKeywords: [],
+  hardNoKeywords: [],
+  preferredKeywords: [],
+  excludedKeywords: [],
+  notes: "",
+};

--- a/src/domain/entities/job.ts
+++ b/src/domain/entities/job.ts
@@ -1,4 +1,6 @@
 import { isoDateTime } from "@/src/domain/types/iso-date-time";
+import { triageProvider } from "@/src/domain/types/triage-provider";
+import { triageStatus } from "@/src/domain/types/triage-status";
 
 export type job = {
   id: string;
@@ -11,6 +13,10 @@ export type job = {
   seniority: string;
   tags: string[];
   description: string | null;
+  triageStatus: triageStatus | null;
+  triageReasons: string[] | null;
+  triagedAt: isoDateTime | null;
+  triageProvider: triageProvider | null;
   publishedAt: isoDateTime | null;
   createdAt: isoDateTime;
   updatedAt: isoDateTime;

--- a/src/domain/entities/user-profile.ts
+++ b/src/domain/entities/user-profile.ts
@@ -1,0 +1,7 @@
+export type userProfile = {
+  mustHaveKeywords: string[];
+  hardNoKeywords: string[];
+  preferredKeywords: string[];
+  excludedKeywords: string[];
+  notes?: string;
+};

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,8 +1,11 @@
 export type { application } from "@/src/domain/entities/application";
 export type { applicationLogEntry } from "@/src/domain/entities/application-log-entry";
 export type { job } from "@/src/domain/entities/job";
+export type { userProfile } from "@/src/domain/entities/user-profile";
 export type { applicationLogEventType } from "@/src/domain/types/application-log-event-type";
 export type { applicationStatus } from "@/src/domain/types/application-status";
 export type { dateOnly } from "@/src/domain/types/date-only";
 export type { isoDateTime } from "@/src/domain/types/iso-date-time";
 export type { priority } from "@/src/domain/types/priority";
+export type { triageProvider } from "@/src/domain/types/triage-provider";
+export type { triageStatus } from "@/src/domain/types/triage-status";

--- a/src/domain/types/triage-provider.ts
+++ b/src/domain/types/triage-provider.ts
@@ -1,0 +1,1 @@
+export type triageProvider = "ollama" | "openai";

--- a/src/domain/types/triage-status.ts
+++ b/src/domain/types/triage-status.ts
@@ -1,0 +1,1 @@
+export type triageStatus = "shortlist" | "maybe" | "reject";

--- a/src/ports/index.ts
+++ b/src/ports/index.ts
@@ -18,3 +18,7 @@ export type {
   jobSourceQuery,
   jobSourceRecord,
 } from "@/src/ports/job-source";
+export type {
+  jobTriageDecision,
+  jobTriagePort,
+} from "@/src/ports/job-triage";

--- a/src/ports/job-repository.ts
+++ b/src/ports/job-repository.ts
@@ -1,11 +1,14 @@
 import { job } from "@/src/domain/entities/job";
 import { isoDateTime } from "@/src/domain/types/iso-date-time";
+import { triageProvider } from "@/src/domain/types/triage-provider";
+import { triageStatus } from "@/src/domain/types/triage-status";
 
 export type listJobsQuery = {
   search?: string;
   seniority?: string;
   source?: string;
   tags?: string[];
+  triageStatus?: triageStatus | "untriaged";
 };
 
 export type jobUpsertRecord = {
@@ -21,6 +24,13 @@ export type jobUpsertRecord = {
   publishedAt: isoDateTime | null;
 };
 
+export type jobTriageUpdate = {
+  triageStatus: triageStatus | null;
+  triageReasons: string[] | null;
+  triagedAt: isoDateTime | null;
+  triageProvider: triageProvider | null;
+};
+
 export type jobUpsertResult = {
   created: number;
   updated: number;
@@ -33,4 +43,5 @@ export interface jobRepository {
     jobs: jobUpsertRecord[];
     now: isoDateTime;
   }): Promise<jobUpsertResult>;
+  updateTriage(input: { id: string; patch: jobTriageUpdate }): Promise<job>;
 }

--- a/src/ports/job-triage.ts
+++ b/src/ports/job-triage.ts
@@ -1,0 +1,22 @@
+import { job } from "@/src/domain/entities/job";
+import { userProfile } from "@/src/domain/entities/user-profile";
+import { triageProvider } from "@/src/domain/types/triage-provider";
+import { triageStatus } from "@/src/domain/types/triage-status";
+
+export type jobTriageDecision = {
+  status: triageStatus;
+  reasons: string[];
+  provider: triageProvider;
+};
+
+export type jobTriagePort = {
+  coarse: (input: {
+    job: job;
+    profile: userProfile;
+  }) => Promise<jobTriageDecision | null>;
+  disambiguate: (input: {
+    job: job;
+    profile: userProfile;
+    previous: jobTriageDecision;
+  }) => Promise<jobTriageDecision | null>;
+};

--- a/src/services/usecases/__tests__/create-application-from-job.test.ts
+++ b/src/services/usecases/__tests__/create-application-from-job.test.ts
@@ -18,6 +18,11 @@ const makeJob = (overrides: Partial<job>): job => ({
   location: "Remoto",
   seniority: "Mid",
   tags: ["React"],
+  description: null,
+  triageStatus: null,
+  triageReasons: null,
+  triagedAt: null,
+  triageProvider: null,
   publishedAt: null,
   createdAt: new Date().toISOString(),
   updatedAt: new Date().toISOString(),
@@ -39,6 +44,9 @@ describe("createApplicationFromJob", () => {
       },
       async upsertByExternalId() {
         return { created: 0, updated: 0 };
+      },
+      async updateTriage() {
+        throw new Error("Not implemented");
       },
     };
 

--- a/src/services/usecases/index.ts
+++ b/src/services/usecases/index.ts
@@ -2,6 +2,11 @@ export type { inboxGroups } from "@/src/services/usecases/list-inbox";
 export type { listApplicationsInput } from "@/src/services/usecases/list-applications";
 export type { listJobsInput } from "@/src/services/usecases/list-jobs";
 export type { ingestJobsInput } from "@/src/services/usecases/ingest-jobs";
+export type {
+  triageJobsInput,
+  triageJobsDeps,
+  triageJobsOutput,
+} from "@/src/services/usecases/triage-jobs";
 export type { getApplicationInput } from "@/src/services/usecases/get-application";
 export type {
   listApplicationLogsInput,
@@ -23,6 +28,7 @@ export { createListInboxUseCase } from "@/src/services/usecases/list-inbox";
 export { createListApplicationsUseCase } from "@/src/services/usecases/list-applications";
 export { createListJobsUseCase } from "@/src/services/usecases/list-jobs";
 export { createIngestJobsUseCase } from "@/src/services/usecases/ingest-jobs";
+export { createTriageJobsUseCase } from "@/src/services/usecases/triage-jobs";
 export { createGetApplicationUseCase } from "@/src/services/usecases/get-application";
 export { createListApplicationLogsUseCase } from "@/src/services/usecases/list-application-logs";
 export { createApplicationFromJobUseCase } from "@/src/services/usecases/create-application-from-job";

--- a/src/services/usecases/list-jobs.ts
+++ b/src/services/usecases/list-jobs.ts
@@ -3,11 +3,20 @@ import { jobRepository, listJobsQuery } from "@/src/ports/job-repository";
 
 export type listJobsInput = listJobsQuery;
 
+const triageRank = (value: job["triageStatus"]) => {
+  if (value === "shortlist") return 0;
+  if (value === "maybe") return 1;
+  if (value === "reject") return 2;
+  return 3;
+};
+
 export const createListJobsUseCase =
   (dependencies: { jobRepository: jobRepository }) =>
   async (input: listJobsInput = {}): Promise<job[]> => {
     const items = await dependencies.jobRepository.list(input);
     return [...items].sort((left, right) =>
-      right.updatedAt.localeCompare(left.updatedAt)
+      triageRank(left.triageStatus) === triageRank(right.triageStatus)
+        ? right.updatedAt.localeCompare(left.updatedAt)
+        : triageRank(left.triageStatus) - triageRank(right.triageStatus)
     );
   };

--- a/src/services/usecases/triage-jobs.ts
+++ b/src/services/usecases/triage-jobs.ts
@@ -1,0 +1,109 @@
+import { job } from "@/src/domain/entities/job";
+import { userProfile } from "@/src/domain/entities/user-profile";
+import { isoDateTime } from "@/src/domain/types/iso-date-time";
+import { jobRepository } from "@/src/ports/job-repository";
+import { jobTriagePort } from "@/src/ports/job-triage";
+import { toIsoNow } from "@/src/services/usecases/date-only";
+import { err, ok, result } from "@/src/services/usecases/result";
+
+export type triageJobsInput = {
+  mode?: "new" | "recent";
+  days?: number;
+};
+
+export type triageJobsOutput = {
+  mode: "new" | "recent";
+  days: number;
+  processed: number;
+  triaged: number;
+  skipped: number;
+};
+
+export type triageJobsDeps = {
+  jobRepository: jobRepository;
+  jobTriage: jobTriagePort;
+  profile: userProfile;
+};
+
+const isRecent = (jobRecord: job, days: number) => {
+  const reference =
+    jobRecord.publishedAt ?? jobRecord.createdAt ?? jobRecord.updatedAt;
+  const parsed = new Date(reference);
+  if (Number.isNaN(parsed.getTime())) {
+    return false;
+  }
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - days);
+  return parsed >= cutoff;
+};
+
+const nowIso = (): isoDateTime => toIsoNow();
+
+export const createTriageJobsUseCase =
+  (dependencies: triageJobsDeps) =>
+  async (
+    input: triageJobsInput = {}
+  ): Promise<result<triageJobsOutput, Error>> => {
+    const mode = input.mode === "recent" ? "recent" : "new";
+    const days = input.days && input.days > 0 ? input.days : 14;
+
+    const items =
+      mode === "new"
+        ? await dependencies.jobRepository.list({ triageStatus: "untriaged" })
+        : await dependencies.jobRepository.list({});
+
+    const candidates =
+      mode === "recent"
+        ? items.filter((jobRecord) => isRecent(jobRecord, days))
+        : items;
+
+    let triaged = 0;
+    let skipped = 0;
+
+    for (const jobRecord of candidates) {
+      const coarse = await dependencies.jobTriage.coarse({
+        job: jobRecord,
+        profile: dependencies.profile,
+      });
+      if (!coarse) {
+        skipped += 1;
+        continue;
+      }
+
+      let finalDecision = coarse;
+      if (coarse.status === "maybe") {
+        const disambiguated = await dependencies.jobTriage.disambiguate({
+          job: jobRecord,
+          profile: dependencies.profile,
+          previous: coarse,
+        });
+        if (disambiguated) {
+          finalDecision = disambiguated;
+        }
+      }
+
+      const triagedAt = nowIso();
+      try {
+        await dependencies.jobRepository.updateTriage({
+          id: jobRecord.id,
+          patch: {
+            triageStatus: finalDecision.status,
+            triageReasons: finalDecision.reasons,
+            triagedAt,
+            triageProvider: finalDecision.provider,
+          },
+        });
+        triaged += 1;
+      } catch (error) {
+        return err(error instanceof Error ? error : new Error("Triage failed."));
+      }
+    }
+
+    return ok({
+      mode,
+      days,
+      processed: candidates.length,
+      triaged,
+      skipped,
+    });
+  };

--- a/supabase/migrations/20260110202000_add_job_triage_fields.sql
+++ b/supabase/migrations/20260110202000_add_job_triage_fields.sql
@@ -1,0 +1,5 @@
+alter table public.jobs
+  add column if not exists triage_status text null,
+  add column if not exists triage_reasons text[] null,
+  add column if not exists triaged_at timestamptz null,
+  add column if not exists triage_provider text null;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -9,6 +9,10 @@ create table if not exists public.jobs (
   seniority text not null,
   tags text[] not null default '{}'::text[],
   description text null,
+  triage_status text null,
+  triage_reasons text[] null,
+  triaged_at timestamptz null,
+  triage_provider text null,
   published_at timestamptz null,
   created_at timestamptz not null,
   updated_at timestamptz not null


### PR DESCRIPTION
## Summary
- add job triage fields to domain, ports, adapters, and schema
- add triage pipeline use case with Ollama/OpenAI adapters and a manual API trigger
- add Jobs UI triage controls, filters, and row display for triage info
- mark Phase 3 as in progress in roadmap

## Notes
- Missing env vars for Ollama/OpenAI skip providers gracefully
- Manual triage uses POST /api/triage/jobs with modes new/recent (14 days)




Refs #10 #11 #12 #13 #14 #15


