### PR TITLE
feat: ollama triage confidence

### DIFF
--- a/src/ports/job-triage.ts
+++ b/src/ports/job-triage.ts
@@ -7,6 +7,8 @@ export type jobTriageDecision = {
   status: triageStatus;
   reasons: string[];
   provider: triageProvider;
+  confidence: number | null;
+  tags: string[];
 };
 
 export type jobTriagePort = {


### PR DESCRIPTION
## Summary
- extend triage decisions with confidence + tags
- enforce confidence gating for Ollama (below 0.75 => maybe)
- update Ollama prompt to request confidence + tags

## Testing
- not run (not requested)

Closes #20