### PR TITLE
feat: add Remote OK job source

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Workx is a single-user job search execution system: it helps you decide what to 
 
 It is built with a Ports & Adapters architecture. By default it runs in **memory mode** (seeded data). When Supabase env vars are present, it uses **Supabase persistence**.
 
-Job discovery foundations are implemented via a manual ingestion flow (Remotive + WWR + Web3 sources) and a jobs list with filters. Automated scraping and ranking are future phases (see `ROADMAP.md`).
+Job discovery foundations are implemented via a manual ingestion flow (Remotive + WWR + Web3 + Remote OK sources) and a jobs list with filters. Automated scraping and ranking are future phases (see `ROADMAP.md`).
 
 ## Daily Decision Loop
 
@@ -54,7 +54,7 @@ npm run dev
 
 Open http://localhost:3000
 
-## Manual Job Ingestion (Remotive + WWR + Web3)
+## Manual Job Ingestion (Remotive + WWR + Web3 + Remote OK)
 
 With the dev server running, you can trigger manual ingestion from Remotive:
 
@@ -73,6 +73,14 @@ Or ingest from Web3:
 ```bash
 curl "http://localhost:3000/api/ingest?source=Web3&limit=50"
 ```
+
+Or ingest from Remote OK:
+
+```bash
+curl "http://localhost:3000/api/ingest?source=Remote%20OK&limit=50"
+```
+
+Remote OK requests attribution and direct job links; keep the source label and URL intact.
 
 To ingest from all configured sources at once:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -73,7 +73,7 @@ Status: Phase 0 complete; current work is post-Phase 0 (Phase 3 in progress).
 
 ---
 
-## Phase 2.2 – Multi-source Job Discovery (Epic 4) 🟡 In Progress
+## Phase 2.2 – Multi-source Job Discovery (Epic 4) ✅ Complete
 
 **Goal:** Expand manual ingestion to multiple sources without UI changes.
 
@@ -87,8 +87,8 @@ Status: Phase 0 complete; current work is post-Phase 0 (Phase 3 in progress).
 **Status update (2026-02-02):**
 - ✅ WWR adapter
 - ✅ Web3 adapter
+- ✅ Remote OK adapter
 - ✅ Multi-source router + generic ingest endpoint
-- ⏳ Remote OK adapter (pending)
 
 **Non-goals:**
 

--- a/src/adapters/remote-ok/job-source.ts
+++ b/src/adapters/remote-ok/job-source.ts
@@ -1,0 +1,125 @@
+import { jobSource, jobSourceRecord } from "@/src/ports/job-source";
+
+type remoteOkJob = {
+  id?: number | string;
+  date?: string;
+  company?: string;
+  position?: string;
+  location?: string;
+  tags?: unknown;
+  description?: string;
+  url?: string;
+  apply_url?: string;
+};
+
+const SOURCE = "Remote OK";
+const API_URL = "https://remoteok.com/api";
+const includeKeywords = ["frontend", "front-end", "react", "ui", "ux", "design"];
+const excludeKeywords = [
+  "sales",
+  "marketing",
+  "recruiter",
+  "account executive",
+];
+
+const toSearchText = (value: string) => value.toLowerCase();
+
+const shouldInclude = (record: jobSourceRecord) => {
+  const haystack = [record.role, record.company, ...record.tags]
+    .map(toSearchText)
+    .join(" ");
+  if (excludeKeywords.some((keyword) => haystack.includes(keyword))) {
+    return false;
+  }
+  return includeKeywords.some((keyword) => haystack.includes(keyword));
+};
+
+const toTags = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value
+      .filter((item): item is string => typeof item === "string")
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  return [];
+};
+
+const normalizeSeniority = (title: string) => {
+  const normalized = title.toLowerCase();
+  if (normalized.includes("intern")) return "Intern";
+  if (normalized.includes("junior") || normalized.includes("jr"))
+    return "Junior";
+  if (normalized.includes("senior") || normalized.includes("sr"))
+    return "Senior";
+  if (
+    normalized.includes("staff") ||
+    normalized.includes("principal") ||
+    normalized.includes("lead")
+  ) {
+    return "Lead";
+  }
+  return "Mid";
+};
+
+const toPublishedAt = (value?: string) => {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+};
+
+const toSourceRecord = (job: remoteOkJob): jobSourceRecord | null => {
+  const role = job.position?.trim();
+  const company = job.company?.trim();
+  const sourceUrl = job.url?.trim() || job.apply_url?.trim();
+  if (!job.id || !role || !company || !sourceUrl) return null;
+
+  return {
+    externalId: String(job.id),
+    source: SOURCE,
+    role,
+    company,
+    location: job.location?.trim() || "Remote",
+    seniority: normalizeSeniority(role),
+    tags: toTags(job.tags),
+    description: job.description?.trim() ?? null,
+    sourceUrl,
+    publishedAt: toPublishedAt(job.date),
+  };
+};
+
+const isJobRecord = (item: unknown): item is remoteOkJob => {
+  if (!item || typeof item !== "object") return false;
+  const record = item as remoteOkJob;
+  return Boolean(record.id && record.position && record.company);
+};
+
+export const createRemoteOkJobSource = (): jobSource => ({
+  list: async (query = {}) => {
+    if (query.source && query.source !== SOURCE) return [];
+
+    const response = await fetch(API_URL);
+    if (!response.ok) {
+      throw new Error("Failed to fetch Remote OK jobs.");
+    }
+
+    const payload = (await response.json()) as unknown;
+    if (!Array.isArray(payload)) {
+      throw new Error("Unexpected Remote OK payload.");
+    }
+
+    const records = payload
+      .filter(isJobRecord)
+      .map(toSourceRecord)
+      .filter((record): record is jobSourceRecord => Boolean(record))
+      .filter(shouldInclude);
+
+    const limit = typeof query.limit === "number" ? query.limit : undefined;
+    return limit ? records.slice(0, limit) : records;
+  },
+});

--- a/src/composition/repositories.ts
+++ b/src/composition/repositories.ts
@@ -9,6 +9,7 @@ import {
 import { memoryStore } from "@/src/adapters/memory/store";
 import { createJobSourceRouter } from "@/src/adapters/job-source-router";
 import { createRemotiveJobSource } from "@/src/adapters/remotive/job-source";
+import { createRemoteOkJobSource } from "@/src/adapters/remote-ok/job-source";
 import { createJobTriageAdapter } from "@/src/adapters/triage/job-triage";
 import { createWeb3JobSource } from "@/src/adapters/web3-jobs/job-source";
 import { createWwrJobSource } from "@/src/adapters/wwr/job-source";
@@ -39,6 +40,7 @@ const createMemoryRepositories = () => {
     jobRepository: createMemoryJobRepository(store),
     jobSource: createJobSourceRouter([
       { source: "Remotive", adapter: createRemotiveJobSource() },
+      { source: "Remote OK", adapter: createRemoteOkJobSource() },
       { source: "Web3", adapter: createWeb3JobSource() },
       { source: "WWR", adapter: createWwrJobSource() },
     ]),
@@ -65,6 +67,7 @@ export async function getRepositories() {
     jobRepository: createSupabaseJobRepository(),
     jobSource: createJobSourceRouter([
       { source: "Remotive", adapter: createRemotiveJobSource() },
+      { source: "Remote OK", adapter: createRemoteOkJobSource() },
       { source: "Web3", adapter: createWeb3JobSource() },
       { source: "WWR", adapter: createWwrJobSource() },
     ]),


### PR DESCRIPTION
## Summary
- add Remote OK adapter using the public JSON feed
- wire Remote OK into job source router
- document Remote OK ingestion and mark Phase 2.2 complete

## Testing
- not run (not requested)

Closes #25
