### PR TITLE
refactor: share job source helpers

### DIFF
--- a/src/adapters/job-source-helpers.ts
+++ b/src/adapters/job-source-helpers.ts
@@ -1,0 +1,38 @@
+export const normalizeSeniority = (title: string) => {
+  const normalized = title.toLowerCase();
+  if (normalized.includes("intern")) return "Intern";
+  if (normalized.includes("junior") || normalized.includes("jr"))
+    return "Junior";
+  if (normalized.includes("senior") || normalized.includes("sr"))
+    return "Senior";
+  if (
+    normalized.includes("staff") ||
+    normalized.includes("principal") ||
+    normalized.includes("lead")
+  ) {
+    return "Lead";
+  }
+  return "Mid";
+};
+
+export const toTags = (value: unknown): string[] => {
+  if (Array.isArray(value)) {
+    return value
+      .filter((item): item is string => typeof item === "string")
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  if (typeof value === "string") {
+    return value
+      .split(",")
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  return [];
+};
+
+export const toPublishedAt = (value?: string | null) => {
+  if (!value) return null;
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
+};

--- a/src/adapters/remote-ok/job-source.ts
+++ b/src/adapters/remote-ok/job-source.ts
@@ -1,4 +1,9 @@
 import { jobSource, jobSourceRecord } from "@/src/ports/job-source";
+import {
+  normalizeSeniority,
+  toPublishedAt,
+  toTags,
+} from "@/src/adapters/job-source-helpers";
 
 type remoteOkJob = {
   id?: number | string;
@@ -32,45 +37,6 @@ const shouldInclude = (record: jobSourceRecord) => {
     return false;
   }
   return includeKeywords.some((keyword) => haystack.includes(keyword));
-};
-
-const toTags = (value: unknown): string[] => {
-  if (Array.isArray(value)) {
-    return value
-      .filter((item): item is string => typeof item === "string")
-      .map((item) => item.trim())
-      .filter(Boolean);
-  }
-  if (typeof value === "string") {
-    return value
-      .split(",")
-      .map((item) => item.trim())
-      .filter(Boolean);
-  }
-  return [];
-};
-
-const normalizeSeniority = (title: string) => {
-  const normalized = title.toLowerCase();
-  if (normalized.includes("intern")) return "Intern";
-  if (normalized.includes("junior") || normalized.includes("jr"))
-    return "Junior";
-  if (normalized.includes("senior") || normalized.includes("sr"))
-    return "Senior";
-  if (
-    normalized.includes("staff") ||
-    normalized.includes("principal") ||
-    normalized.includes("lead")
-  ) {
-    return "Lead";
-  }
-  return "Mid";
-};
-
-const toPublishedAt = (value?: string) => {
-  if (!value) return null;
-  const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
 };
 
 const toSourceRecord = (job: remoteOkJob): jobSourceRecord | null => {

--- a/src/adapters/remotive/job-source.ts
+++ b/src/adapters/remotive/job-source.ts
@@ -1,4 +1,8 @@
 import { jobSource, jobSourceRecord } from "@/src/ports/job-source";
+import {
+  normalizeSeniority,
+  toPublishedAt,
+} from "@/src/adapters/job-source-helpers";
 
 type remotiveJob = {
   id: number;
@@ -30,35 +34,6 @@ const shouldInclude = (record: jobSourceRecord) => {
     return false;
   }
   return includeKeywords.some((keyword) => haystack.includes(keyword));
-};
-
-const normalizeSeniority = (title: string) => {
-  const normalized = title.toLowerCase();
-  if (normalized.includes("intern")) {
-    return "Intern";
-  }
-  if (normalized.includes("junior") || normalized.includes("jr")) {
-    return "Junior";
-  }
-  if (normalized.includes("senior") || normalized.includes("sr")) {
-    return "Senior";
-  }
-  if (
-    normalized.includes("staff") ||
-    normalized.includes("principal") ||
-    normalized.includes("lead")
-  ) {
-    return "Lead";
-  }
-  return "Mid";
-};
-
-const toPublishedAt = (value: string) => {
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) {
-    return null;
-  }
-  return parsed.toISOString();
 };
 
 const toSourceRecord = (job: remotiveJob): jobSourceRecord => ({

--- a/src/adapters/web3-jobs/job-source.ts
+++ b/src/adapters/web3-jobs/job-source.ts
@@ -1,4 +1,8 @@
 import { jobSource, jobSourceRecord } from "@/src/ports/job-source";
+import {
+  normalizeSeniority,
+  toTags,
+} from "@/src/adapters/job-source-helpers";
 
 type web3Job = {
   id?: number | string;
@@ -25,39 +29,6 @@ const shouldInclude = (record: jobSourceRecord) => {
     .map(toSearchText)
     .join(" ");
   return includeKeywords.some((keyword) => haystack.includes(keyword));
-};
-
-const toTags = (value: unknown): string[] => {
-  if (Array.isArray(value)) {
-    return value
-      .filter((item): item is string => typeof item === "string")
-      .map((item) => item.trim())
-      .filter(Boolean);
-  }
-  if (typeof value === "string") {
-    return value
-      .split(",")
-      .map((item) => item.trim())
-      .filter(Boolean);
-  }
-  return [];
-};
-
-const normalizeSeniority = (title: string) => {
-  const normalized = title.toLowerCase();
-  if (normalized.includes("intern")) return "Intern";
-  if (normalized.includes("junior") || normalized.includes("jr"))
-    return "Junior";
-  if (normalized.includes("senior") || normalized.includes("sr"))
-    return "Senior";
-  if (
-    normalized.includes("staff") ||
-    normalized.includes("principal") ||
-    normalized.includes("lead")
-  ) {
-    return "Lead";
-  }
-  return "Mid";
 };
 
 const toPublishedAt = (job: web3Job) => {

--- a/src/adapters/wwr/job-source.ts
+++ b/src/adapters/wwr/job-source.ts
@@ -1,5 +1,9 @@
 import Parser from "rss-parser";
 import { jobSource, jobSourceRecord } from "@/src/ports/job-source";
+import {
+  normalizeSeniority,
+  toPublishedAt,
+} from "@/src/adapters/job-source-helpers";
 
 const SOURCE = "WWR";
 const FEED_URL =
@@ -26,29 +30,6 @@ const stripHtml = (value: string) =>
     .replace(/<[^>]*>/g, " ")
     .replace(/\s+/g, " ")
     .trim();
-
-const toPublishedAt = (value?: string | null) => {
-  if (!value) return null;
-  const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? null : parsed.toISOString();
-};
-
-const normalizeSeniority = (title: string) => {
-  const normalized = title.toLowerCase();
-  if (normalized.includes("intern")) return "Intern";
-  if (normalized.includes("junior") || normalized.includes("jr"))
-    return "Junior";
-  if (normalized.includes("senior") || normalized.includes("sr"))
-    return "Senior";
-  if (
-    normalized.includes("staff") ||
-    normalized.includes("principal") ||
-    normalized.includes("lead")
-  ) {
-    return "Lead";
-  }
-  return "Mid";
-};
 
 const splitOn = (value: string, delimiter: string) => {
   const index = value.indexOf(delimiter);


### PR DESCRIPTION
## Summary
- extract shared helpers for job source adapters
- keep per-source filters and mappings intact

## Testing
- not run (not requested)

Closes #67
