### PR TITLE
feat: triage toast feedback

### DIFF
--- a/app/jobs/TriageControls.tsx
+++ b/app/jobs/TriageControls.tsx
@@ -48,13 +48,21 @@ export default function TriageControls() {
       if (!response.ok || !payload.ok) {
         throw new Error(payload.error ?? "No pudimos analizar trabajos.");
       }
+      const processed = payload.processed ?? 0;
+      const triaged = payload.triaged ?? 0;
+      const skipped = payload.skipped ?? 0;
       const skippedByCap = payload.openaiSkippedCap ?? 0;
+      const summaryParts = [
+        `Procesados: ${processed}`,
+        `Actualizados: ${triaged}`,
+        `Omitidos: ${skipped}`,
+      ];
+      if (skippedByCap > 0) {
+        summaryParts.push(`OpenAI limite: ${skippedByCap}`);
+      }
       toast({
-        title: `Analisis listo: ${payload.triaged ?? 0} actualizados.`,
-        description:
-          skippedByCap > 0
-            ? `Se omitieron ${skippedByCap} revisiones por limite diario de OpenAI.`
-            : undefined,
+        title: "Analisis listo.",
+        description: summaryParts.join(" • "),
         variant: "success",
       });
       handleClose();


### PR DESCRIPTION
## Summary
- show processed/updated/skipped counts in triage toast
- include OpenAI cap skips in the summary

## Testing
- not run (not requested)

Closes #70
