### PR TITLE
feat: triage progress indicator

### DIFF
--- a/app/jobs/TriageControls.tsx
+++ b/app/jobs/TriageControls.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { useToast } from "@/components/ui/use-toast";
+import { emitTriageStatus } from "@/src/lib/triage-status";
 
 type triageMode = "new" | "recent";
 
@@ -30,6 +31,7 @@ export default function TriageControls() {
   const runTriage = async (mode: triageMode) => {
     if (pendingMode) return;
     setPendingMode(mode);
+    emitTriageStatus(true);
     try {
       const response = await fetch("/api/triage/jobs", {
         method: "POST",
@@ -69,6 +71,7 @@ export default function TriageControls() {
       });
     } finally {
       setPendingMode(null);
+      emitTriageStatus(false);
     }
   };
 

--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -4,6 +4,7 @@ import IngestDialog from "@/src/components/IngestDialog";
 import JobsFilters from "@/src/components/JobsFilters";
 import JobTable from "@/src/components/JobTable";
 import JobsPagination from "@/src/components/JobsPagination";
+import JobsTriageStatus from "@/src/components/JobsTriageStatus";
 import TriageControls from "@/app/jobs/TriageControls";
 
 type jobsPageProps = {
@@ -92,6 +93,7 @@ export default async function JobsPage({ searchParams }: jobsPageProps) {
             initialSource={rawSource ?? "all"}
             initialTriage={triageValue}
           />
+          <JobsTriageStatus />
         </div>
 
         <JobTable

--- a/src/components/JobsTriageStatus.tsx
+++ b/src/components/JobsTriageStatus.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { TRIAGE_STATUS_EVENT } from "@/src/lib/triage-status";
+
+export default function JobsTriageStatus() {
+  const [active, setActive] = useState(false);
+
+  useEffect(() => {
+    const handler = (event: Event) => {
+      const detail = (event as CustomEvent<{ active: boolean }>).detail;
+      setActive(Boolean(detail?.active));
+    };
+
+    window.addEventListener(TRIAGE_STATUS_EVENT, handler);
+    return () => window.removeEventListener(TRIAGE_STATUS_EVENT, handler);
+  }, []);
+
+  if (!active) return null;
+
+  return (
+    <div className="ml-auto flex items-center gap-2 text-xs text-muted-foreground">
+      <Loader2 className="size-4 animate-spin" />
+      <span>Clasificacion en curso...</span>
+    </div>
+  );
+}

--- a/src/lib/triage-status.ts
+++ b/src/lib/triage-status.ts
@@ -1,0 +1,14 @@
+export const TRIAGE_STATUS_EVENT = "workx:triage-status";
+
+export type triageStatusDetail = {
+  active: boolean;
+};
+
+export const emitTriageStatus = (active: boolean) => {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(
+    new CustomEvent<triageStatusDetail>(TRIAGE_STATUS_EVENT, {
+      detail: { active },
+    })
+  );
+};


### PR DESCRIPTION
## Summary
- broadcast triage progress status from the modal
- show a header spinner while triage is running

## Testing
- not run (not requested)

Closes #76
