### PR TITLE
perf: reduce duplicate queries

### DIFF
--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -34,7 +34,7 @@ const parsePositiveInt = (value?: string) => {
 const getSortDate = (record: job) => record.publishedAt ?? null;
 
 export default async function JobsPage({ searchParams }: jobsPageProps) {
-  const { listApplications, listJobs } = await getUseCases();
+  const { listApplications, listJobs, listJobSources } = await getUseCases();
   const params = (await searchParams) ?? {};
   const search = params.q?.trim() ?? "";
   const rawSource = params.source;
@@ -53,14 +53,14 @@ export default async function JobsPage({ searchParams }: jobsPageProps) {
       ? triageValue
       : undefined;
 
-  const [jobs, allJobs, applications] = await Promise.all([
+  const [jobs, sources, applications] = await Promise.all([
     listJobs({
       search: search || undefined,
       source,
       triageStatus,
       needsRetriage,
     }),
-    listJobs(),
+    listJobSources(),
     listApplications(),
   ]);
   const sortedJobs =
@@ -91,7 +91,7 @@ export default async function JobsPage({ searchParams }: jobsPageProps) {
     .map((application) => application.jobId)
     .filter((jobId): jobId is string => Boolean(jobId));
 
-  const sources = Array.from(new Set(allJobs.map((job) => job.source))).sort();
+  const sortedSources = [...new Set(sources)].sort();
   return (
     <div className="space-y-6">
       <header className="flex flex-wrap items-center justify-between gap-3">
@@ -110,7 +110,7 @@ export default async function JobsPage({ searchParams }: jobsPageProps) {
       <section className="rounded-lg border border-border bg-card">
         <div className="flex flex-wrap items-end gap-3 border-b border-border px-4 py-3">
           <JobsFilters
-            sources={sources}
+            sources={sortedSources}
             initialSearch={search}
             initialSource={rawSource ?? "all"}
             initialTriage={triageValue}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,13 +7,13 @@ import { formatDate } from "@/src/lib/format";
 import JobTable from "@/src/components/JobTable";
 
 export default async function Home() {
-  const { listInbox, listApplications, listJobs, listApplicationLogs } =
+  const { listInboxOverview, listJobs, listApplicationLogs } =
     await getUseCases();
-  const [{ overdue }, applications, jobs] = await Promise.all([
-    listInbox(),
-    listApplications(),
+  const [{ inbox, applications }, jobs] = await Promise.all([
+    listInboxOverview(),
     listJobs(),
   ]);
+  const { overdue } = inbox;
   const totalApplications = applications.length;
   const activeInterviews = applications.filter(
     (item) => item.status === "screen" || item.status === "tech"

--- a/src/adapters/memory/job-repository.ts
+++ b/src/adapters/memory/job-repository.ts
@@ -109,6 +109,9 @@ export const createMemoryJobRepository = (
       return true;
     });
   },
+  async listSources() {
+    return Array.from(new Set(store.jobs.map((record) => record.source)));
+  },
   async getById(query: { id: string }) {
     return store.jobs.find((record) => record.id === query.id) ?? null;
   },

--- a/src/adapters/supabase/job-repository.ts
+++ b/src/adapters/supabase/job-repository.ts
@@ -98,6 +98,16 @@ export const createSupabaseJobRepository = (): jobRepository => ({
     }
     return (data ?? []).map((row) => toJob(row as jobRow));
   },
+  async listSources() {
+    const { data, error } = await supabase.from("jobs").select("source");
+    if (error) {
+      throw new Error(error.message);
+    }
+    const sources = (data ?? [])
+      .map((row) => row.source)
+      .filter((value): value is string => Boolean(value));
+    return Array.from(new Set(sources));
+  },
   async getById(query: { id: string }) {
     const { data, error } = await supabase
       .from("jobs")

--- a/src/composition/usecases.ts
+++ b/src/composition/usecases.ts
@@ -5,7 +5,9 @@ import { createGetJobUseCase } from "@/src/services/usecases/get-job";
 import { createListApplicationLogsUseCase } from "@/src/services/usecases/list-application-logs";
 import { createListApplicationsUseCase } from "@/src/services/usecases/list-applications";
 import { createListInboxUseCase } from "@/src/services/usecases/list-inbox";
+import { createListInboxOverviewUseCase } from "@/src/services/usecases/list-inbox-overview";
 import { createListJobsUseCase } from "@/src/services/usecases/list-jobs";
+import { createListJobSourcesUseCase } from "@/src/services/usecases/list-job-sources";
 import { updateApplicationUseCase } from "@/src/services/usecases/update-application";
 import { createIngestJobsUseCase } from "@/src/services/usecases/ingest-jobs";
 import { createArchiveApplicationUseCase } from "@/src/services/usecases/archive-application";
@@ -24,9 +26,15 @@ async function buildUseCases() {
     listInbox: createListInboxUseCase({
       applicationRepository: repositories.applicationRepository,
     }),
+    listInboxOverview: createListInboxOverviewUseCase({
+      applicationRepository: repositories.applicationRepository,
+    }),
     listJobs: createListJobsUseCase({
       jobRepository: repositories.jobRepository,
       profile: defaultUserProfile,
+    }),
+    listJobSources: createListJobSourcesUseCase({
+      jobRepository: repositories.jobRepository,
     }),
     ingestJobs: createIngestJobsUseCase({
       jobSource: repositories.jobSource,

--- a/src/ports/job-repository.ts
+++ b/src/ports/job-repository.ts
@@ -39,6 +39,7 @@ export type jobUpsertResult = {
 
 export interface jobRepository {
   list(query: listJobsQuery): Promise<job[]>;
+  listSources(): Promise<string[]>;
   getById(query: { id: string }): Promise<job | null>;
   upsertByExternalId(input: {
     jobs: jobUpsertRecord[];

--- a/src/services/usecases/index.ts
+++ b/src/services/usecases/index.ts
@@ -1,4 +1,5 @@
 export type { inboxGroups } from "@/src/services/usecases/list-inbox";
+export type { inboxOverview } from "@/src/services/usecases/list-inbox-overview";
 export type { listApplicationsInput } from "@/src/services/usecases/list-applications";
 export type { listJobsInput } from "@/src/services/usecases/list-jobs";
 export type { ingestJobsInput } from "@/src/services/usecases/ingest-jobs";
@@ -26,8 +27,10 @@ export type {
 } from "@/src/services/usecases/archive-application";
 export type { result, resultErr, resultOk } from "@/src/services/usecases/result";
 export { createListInboxUseCase } from "@/src/services/usecases/list-inbox";
+export { createListInboxOverviewUseCase } from "@/src/services/usecases/list-inbox-overview";
 export { createListApplicationsUseCase } from "@/src/services/usecases/list-applications";
 export { createListJobsUseCase } from "@/src/services/usecases/list-jobs";
+export { createListJobSourcesUseCase } from "@/src/services/usecases/list-job-sources";
 export { createIngestJobsUseCase } from "@/src/services/usecases/ingest-jobs";
 export { createTriageJobsUseCase } from "@/src/services/usecases/triage-jobs";
 export { createGetApplicationUseCase } from "@/src/services/usecases/get-application";

--- a/src/services/usecases/list-inbox-overview.ts
+++ b/src/services/usecases/list-inbox-overview.ts
@@ -1,0 +1,21 @@
+import { application } from "@/src/domain/entities/application";
+import { applicationRepository } from "@/src/ports/application-repository";
+import { buildInboxGroups, inboxGroups } from "@/src/services/usecases/list-inbox";
+
+export type inboxOverview = {
+  inbox: inboxGroups;
+  applications: application[];
+};
+
+export const createListInboxOverviewUseCase =
+  (dependencies: { applicationRepository: applicationRepository }) =>
+  async (): Promise<inboxOverview> => {
+    const items = await dependencies.applicationRepository.list({});
+    const sorted = [...items].sort((left, right) =>
+      right.updatedAt.localeCompare(left.updatedAt)
+    );
+    return {
+      inbox: buildInboxGroups(sorted),
+      applications: sorted,
+    };
+  };

--- a/src/services/usecases/list-job-sources.ts
+++ b/src/services/usecases/list-job-sources.ts
@@ -1,0 +1,5 @@
+import { jobRepository } from "@/src/ports/job-repository";
+
+export const createListJobSourcesUseCase =
+  (dependencies: { jobRepository: jobRepository }) =>
+  async (): Promise<string[]> => dependencies.jobRepository.listSources();


### PR DESCRIPTION
## Summary
- add listJobSources + listInboxOverview usecases to reduce duplicate queries
- use listJobSources in Jobs and listInboxOverview in Home
- keep listInbox behavior intact for Inbox page

## Testing
- not run (not requested)

Closes #97
