### PR TITLE
fix: guard toast ids in dismiss

### DIFF
--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -83,7 +83,9 @@ export const reducer = (state: toastState, action: action): toastState => {
         addToRemoveQueue(toastId);
       } else {
         state.toasts.forEach((toast) => {
-          addToRemoveQueue(toast.id);
+          if (toast.id) {
+            addToRemoveQueue(toast.id);
+          }
         });
       }
 


### PR DESCRIPTION
## Summary
- Guard toast.id before enqueueing dismissal to satisfy TS and prevent undefined IDs.

## Testing
- Not run (not requested).

Closes #114
