### PR TITLE
build: allow custom toast ids

### DIFF
--- a/components/ui/use-toast.ts
+++ b/components/ui/use-toast.ts
@@ -126,10 +126,10 @@ function dispatch(action: action) {
   });
 }
 
-type toastInput = Omit<ToastProps, "id">;
+type toastInput = Omit<ToastProps, "id"> & { id?: string };
 
-function toast({ ...props }: toastInput) {
-  const id = genId();
+function toast({ id: inputId, ...props }: toastInput) {
+  const id = inputId ?? genId();
 
   const update = (props: ToastProps) =>
     dispatch({


### PR DESCRIPTION
## Summary
- Allow passing an optional `id` when creating a toast.
- Preserve generated ids as fallback.

## Testing
- Not run (not requested).

Closes #114