### PR TITLE
feat: daily ingest cap + status UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,4 @@ RANK_PROVIDER=ollama
 
 # Optional: Web3 Jobs source
 WEB3_CAREER_TOKEN=
+INGEST_DAILY_CAP=2

--- a/app/api/ingest/remotive/route.ts
+++ b/app/api/ingest/remotive/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { getUseCases } from "@/src/composition/usecases";
+import { isIngestCapError } from "@/src/services/usecases/ingest-jobs-with-cap";
 import { HOME_CACHE_PROFILE, HOME_CACHE_TAG } from "@/src/lib/cache-tags";
 
 export async function GET(request: Request) {
@@ -11,12 +12,16 @@ export async function GET(request: Request) {
     Number.isFinite(limit) && limit && limit > 0 ? limit : undefined;
 
   try {
-    const { ingestJobs } = await getUseCases();
-    const result = await ingestJobs({ source: "Remotive", limit: safeLimit });
+    const { ingestJobsWithCap } = await getUseCases();
+    const result = await ingestJobsWithCap({
+      source: "Remotive",
+      limit: safeLimit,
+    });
     if (!result.ok) {
+      const status = isIngestCapError(result.error) ? 429 : 500;
       return NextResponse.json(
-        { ok: false, error: "No pudimos ingestar trabajos." },
-        { status: 500 }
+        { ok: false, error: result.error.message },
+        { status }
       );
     }
     revalidateTag(HOME_CACHE_TAG, HOME_CACHE_PROFILE);

--- a/app/api/ingest/route.ts
+++ b/app/api/ingest/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { getUseCases } from "@/src/composition/usecases";
+import { isIngestCapError } from "@/src/services/usecases/ingest-jobs-with-cap";
 import { HOME_CACHE_PROFILE, HOME_CACHE_TAG } from "@/src/lib/cache-tags";
 
 export async function GET(request: Request) {
@@ -13,12 +14,13 @@ export async function GET(request: Request) {
   const source = sourceParam?.trim() || undefined;
 
   try {
-    const { ingestJobs } = await getUseCases();
-    const result = await ingestJobs({ source, limit: safeLimit });
+    const { ingestJobsWithCap } = await getUseCases();
+    const result = await ingestJobsWithCap({ source, limit: safeLimit });
     if (!result.ok) {
+      const status = isIngestCapError(result.error) ? 429 : 500;
       return NextResponse.json(
-        { ok: false, error: "No pudimos ingestar trabajos." },
-        { status: 500 }
+        { ok: false, error: result.error.message },
+        { status }
       );
     }
     revalidateTag(HOME_CACHE_TAG, HOME_CACHE_PROFILE);

--- a/app/api/ingest/status/route.ts
+++ b/app/api/ingest/status/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import { getUseCases } from "@/src/composition/usecases";
+
+export async function GET() {
+  try {
+    const { getIngestStatus } = await getUseCases();
+    const status = await getIngestStatus();
+    return NextResponse.json({ ok: true, ...status });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        ok: false,
+        error:
+          error instanceof Error
+            ? error.message
+            : "No pudimos cargar el estado de ingestas.",
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/ingest/wwr/route.ts
+++ b/app/api/ingest/wwr/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { revalidateTag } from "next/cache";
 import { getUseCases } from "@/src/composition/usecases";
+import { isIngestCapError } from "@/src/services/usecases/ingest-jobs-with-cap";
 import { HOME_CACHE_PROFILE, HOME_CACHE_TAG } from "@/src/lib/cache-tags";
 
 export async function GET(request: Request) {
@@ -11,12 +12,13 @@ export async function GET(request: Request) {
     Number.isFinite(limit) && limit && limit > 0 ? limit : undefined;
 
   try {
-    const { ingestJobs } = await getUseCases();
-    const result = await ingestJobs({ source: "WWR", limit: safeLimit });
+    const { ingestJobsWithCap } = await getUseCases();
+    const result = await ingestJobsWithCap({ source: "WWR", limit: safeLimit });
     if (!result.ok) {
+      const status = isIngestCapError(result.error) ? 429 : 500;
       return NextResponse.json(
-        { ok: false, error: "No pudimos ingestar trabajos." },
-        { status: 500 }
+        { ok: false, error: result.error.message },
+        { status }
       );
     }
     revalidateTag(HOME_CACHE_TAG, HOME_CACHE_PROFILE);

--- a/src/adapters/memory/ingest-run-repository.ts
+++ b/src/adapters/memory/ingest-run-repository.ts
@@ -1,0 +1,33 @@
+import {
+  ingestRunRepository,
+  ingestRunRecord,
+} from "@/src/ports/ingest-run-repository";
+import { memoryStore } from "@/src/adapters/memory/store";
+import { ingestRun } from "@/src/domain/entities/ingest-run";
+
+let idCounter = 0;
+const createId = () => {
+  idCounter += 1;
+  return `ingest-${Date.now()}-${idCounter}`;
+};
+
+export const createMemoryIngestRunRepository = (
+  store: memoryStore
+): ingestRunRepository => ({
+  async count(query) {
+    const since = query.since;
+    return store.ingestRuns.filter((run) => run.createdAt >= since).length;
+  },
+  async create(record: ingestRunRecord) {
+    const run: ingestRun = {
+      id: createId(),
+      source: record.source,
+      status: record.status,
+      created: record.created,
+      updated: record.updated,
+      error: record.error ?? null,
+      createdAt: record.createdAt,
+    };
+    store.ingestRuns.push(run);
+  },
+});

--- a/src/adapters/memory/store.ts
+++ b/src/adapters/memory/store.ts
@@ -1,9 +1,11 @@
 import { application } from "@/src/domain/entities/application";
 import { applicationLogEntry } from "@/src/domain/entities/application-log-entry";
+import { ingestRun } from "@/src/domain/entities/ingest-run";
 import { job } from "@/src/domain/entities/job";
 
 export type memoryStore = {
   applications: application[];
   applicationLogs: applicationLogEntry[];
+  ingestRuns: ingestRun[];
   jobs: job[];
 };

--- a/src/adapters/supabase/ingest-run-repository.ts
+++ b/src/adapters/supabase/ingest-run-repository.ts
@@ -1,0 +1,43 @@
+import { supabase } from "@/src/adapters/supabase/client";
+import {
+  ingestRunRepository,
+  ingestRunRecord,
+} from "@/src/ports/ingest-run-repository";
+
+type ingestRunRow = {
+  id: string;
+  source: string | null;
+  status: string;
+  created: number;
+  updated: number;
+  error: string | null;
+  created_at: string;
+};
+
+export const createSupabaseIngestRunRepository = (): ingestRunRepository => ({
+  async count(query) {
+    const { count, error } = await supabase
+      .from("ingest_runs")
+      .select("id", { count: "exact", head: true })
+      .gte("created_at", query.since);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+    return count ?? 0;
+  },
+  async create(record: ingestRunRecord) {
+    const { error } = await supabase.from("ingest_runs").insert({
+      source: record.source,
+      status: record.status,
+      created: record.created,
+      updated: record.updated,
+      error: record.error,
+      created_at: record.createdAt,
+    });
+
+    if (error) {
+      throw new Error(error.message);
+    }
+  },
+});

--- a/src/composition/repositories.ts
+++ b/src/composition/repositories.ts
@@ -1,5 +1,6 @@
 import { createMemoryApplicationLogRepository } from "@/src/adapters/memory/application-log-repository";
 import { createMemoryApplicationRepository } from "@/src/adapters/memory/application-repository";
+import { createMemoryIngestRunRepository } from "@/src/adapters/memory/ingest-run-repository";
 import { createMemoryJobRepository } from "@/src/adapters/memory/job-repository";
 import {
   seedApplicationLogs,
@@ -28,6 +29,7 @@ const createMemoryRepositories = () => {
     ({
       applications: [...seedApplications],
       applicationLogs: [...seedApplicationLogs],
+      ingestRuns: [],
       jobs: [...seedJobs],
     } satisfies memoryStore);
 
@@ -38,6 +40,7 @@ const createMemoryRepositories = () => {
   return {
     applicationRepository: createMemoryApplicationRepository(store),
     applicationLogRepository: createMemoryApplicationLogRepository(store),
+    ingestRunRepository: createMemoryIngestRunRepository(store),
     jobRepository: createMemoryJobRepository(store),
     jobSource: createJobSourceRouter([
       { source: "Remotive", adapter: createRemotiveJobSource() },
@@ -62,10 +65,14 @@ export async function getRepositories() {
   const { createSupabaseJobRepository } = await import(
     "@/src/adapters/supabase/job-repository"
   );
+  const { createSupabaseIngestRunRepository } = await import(
+    "@/src/adapters/supabase/ingest-run-repository"
+  );
 
   return {
     applicationRepository: createSupabaseApplicationRepository(),
     applicationLogRepository: createSupabaseApplicationLogRepository(),
+    ingestRunRepository: createSupabaseIngestRunRepository(),
     jobRepository: createSupabaseJobRepository(),
     jobSource: createJobSourceRouter([
       { source: "Remotive", adapter: createRemotiveJobSource() },

--- a/src/composition/usecases.ts
+++ b/src/composition/usecases.ts
@@ -12,6 +12,8 @@ import { createListJobsPageUseCase } from "@/src/services/usecases/list-jobs-pag
 import { createListJobSourcesUseCase } from "@/src/services/usecases/list-job-sources";
 import { updateApplicationUseCase } from "@/src/services/usecases/update-application";
 import { createIngestJobsUseCase } from "@/src/services/usecases/ingest-jobs";
+import { createIngestJobsWithCapUseCase } from "@/src/services/usecases/ingest-jobs-with-cap";
+import { createGetIngestStatusUseCase } from "@/src/services/usecases/ingest-status";
 import { createArchiveApplicationUseCase } from "@/src/services/usecases/archive-application";
 import { createTriageJobsUseCase } from "@/src/services/usecases/triage-jobs";
 import { createRankShortlistUseCase } from "@/src/services/usecases/rank-shortlist";
@@ -50,6 +52,14 @@ async function buildUseCases() {
     ingestJobs: createIngestJobsUseCase({
       jobSource: repositories.jobSource,
       jobRepository: repositories.jobRepository,
+    }),
+    ingestJobsWithCap: createIngestJobsWithCapUseCase({
+      jobSource: repositories.jobSource,
+      jobRepository: repositories.jobRepository,
+      ingestRunRepository: repositories.ingestRunRepository,
+    }),
+    getIngestStatus: createGetIngestStatusUseCase({
+      ingestRunRepository: repositories.ingestRunRepository,
     }),
     triageJobs: createTriageJobsUseCase({
       jobRepository: repositories.jobRepository,

--- a/src/domain/entities/ingest-run.ts
+++ b/src/domain/entities/ingest-run.ts
@@ -1,0 +1,13 @@
+import { isoDateTime } from "@/src/domain/types/iso-date-time";
+
+export type ingestRunStatus = "success" | "failed";
+
+export type ingestRun = {
+  id: string;
+  source: string | null;
+  status: ingestRunStatus;
+  created: number;
+  updated: number;
+  error: string | null;
+  createdAt: isoDateTime;
+};

--- a/src/ports/index.ts
+++ b/src/ports/index.ts
@@ -23,6 +23,11 @@ export type {
   jobSourceRecord,
 } from "@/src/ports/job-source";
 export type {
+  ingestRunRepository,
+  ingestRunRecord,
+  countIngestRunsQuery,
+} from "@/src/ports/ingest-run-repository";
+export type {
   jobTriageDecision,
   jobTriagePort,
 } from "@/src/ports/job-triage";

--- a/src/ports/ingest-run-repository.ts
+++ b/src/ports/ingest-run-repository.ts
@@ -1,0 +1,20 @@
+import { isoDateTime } from "@/src/domain/types/iso-date-time";
+import { ingestRunStatus } from "@/src/domain/entities/ingest-run";
+
+export type ingestRunRecord = {
+  source: string | null;
+  status: ingestRunStatus;
+  created: number;
+  updated: number;
+  error: string | null;
+  createdAt: isoDateTime;
+};
+
+export type countIngestRunsQuery = {
+  since: isoDateTime;
+};
+
+export interface ingestRunRepository {
+  count(query: countIngestRunsQuery): Promise<number>;
+  create(record: ingestRunRecord): Promise<void>;
+}

--- a/src/services/usecases/index.ts
+++ b/src/services/usecases/index.ts
@@ -9,6 +9,12 @@ export type {
 } from "@/src/services/usecases/list-jobs-page";
 export type { ingestJobsInput } from "@/src/services/usecases/ingest-jobs";
 export type {
+  ingestJobsWithCapInput,
+  ingestJobsWithCapOutput,
+  ingestJobsWithCapDeps,
+} from "@/src/services/usecases/ingest-jobs-with-cap";
+export type { ingestStatus } from "@/src/services/usecases/ingest-status";
+export type {
   triageJobsInput,
   triageJobsDeps,
   triageJobsOutput,
@@ -49,6 +55,8 @@ export { createListJobsUseCase } from "@/src/services/usecases/list-jobs";
 export { createListJobsPageUseCase } from "@/src/services/usecases/list-jobs-page";
 export { createListJobSourcesUseCase } from "@/src/services/usecases/list-job-sources";
 export { createIngestJobsUseCase } from "@/src/services/usecases/ingest-jobs";
+export { createIngestJobsWithCapUseCase } from "@/src/services/usecases/ingest-jobs-with-cap";
+export { createGetIngestStatusUseCase } from "@/src/services/usecases/ingest-status";
 export { createTriageJobsUseCase } from "@/src/services/usecases/triage-jobs";
 export { createRankShortlistUseCase } from "@/src/services/usecases/rank-shortlist";
 export { createGetApplicationUseCase } from "@/src/services/usecases/get-application";

--- a/src/services/usecases/ingest-jobs-with-cap.ts
+++ b/src/services/usecases/ingest-jobs-with-cap.ts
@@ -1,0 +1,105 @@
+import { jobRepository, jobUpsertRecord } from "@/src/ports/job-repository";
+import { jobSource, jobSourceQuery } from "@/src/ports/job-source";
+import { ingestRunRepository } from "@/src/ports/ingest-run-repository";
+import { toIsoNow } from "@/src/services/usecases/date-only";
+import { err, ok, result } from "@/src/services/usecases/result";
+import { getDailyIngestCap, getStartOfTodayIso } from "@/src/services/usecases/ingest-status";
+
+export type ingestJobsWithCapInput = jobSourceQuery;
+
+export type ingestJobsWithCapOutput = {
+  fetched: number;
+  created: number;
+  updated: number;
+  used: number;
+  limit: number;
+  remaining: number;
+};
+
+export type ingestJobsWithCapDeps = {
+  jobSource: jobSource;
+  jobRepository: jobRepository;
+  ingestRunRepository: ingestRunRepository;
+};
+
+const capReachedMessage = (used: number, limit: number) =>
+  `Limite diario alcanzado (${used}/${limit}).`;
+
+export const createIngestJobsWithCapUseCase =
+  (dependencies: ingestJobsWithCapDeps) =>
+  async (
+    input: ingestJobsWithCapInput = {}
+  ): Promise<result<ingestJobsWithCapOutput, Error>> => {
+    const limit = getDailyIngestCap();
+    if (limit <= 0) {
+      return err(new Error("Ingesta deshabilitada por limite diario."));
+    }
+
+    const since = getStartOfTodayIso();
+    const used = await dependencies.ingestRunRepository.count({ since });
+    if (used >= limit) {
+      return err(new Error(capReachedMessage(used, limit)));
+    }
+
+    const now = toIsoNow();
+    const source = input.source ?? null;
+
+    try {
+      const jobs = await dependencies.jobSource.list(input);
+      const upsertRecords: jobUpsertRecord[] = jobs.map((job) => ({
+        externalId: job.externalId,
+        source: job.source,
+        role: job.role,
+        company: job.company,
+        location: job.location,
+        seniority: job.seniority,
+        tags: job.tags,
+        description: job.description ?? null,
+        sourceUrl: job.sourceUrl,
+        publishedAt: job.publishedAt,
+      }));
+
+      const upserted =
+        upsertRecords.length > 0
+          ? await dependencies.jobRepository.upsertByExternalId({
+              jobs: upsertRecords,
+              now,
+            })
+          : { created: 0, updated: 0 };
+
+      await dependencies.ingestRunRepository.create({
+        source,
+        status: "success",
+        created: upserted.created,
+        updated: upserted.updated,
+        error: null,
+        createdAt: now,
+      });
+
+      const usedAfter = await dependencies.ingestRunRepository.count({ since });
+
+      return ok({
+        fetched: jobs.length,
+        created: upserted.created,
+        updated: upserted.updated,
+        used: usedAfter,
+        limit,
+        remaining: Math.max(0, limit - usedAfter),
+      });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "No pudimos ingestar trabajos.";
+      await dependencies.ingestRunRepository.create({
+        source,
+        status: "failed",
+        created: 0,
+        updated: 0,
+        error: message,
+        createdAt: now,
+      });
+      return err(error instanceof Error ? error : new Error(message));
+    }
+  };
+
+export const isIngestCapError = (error: Error) =>
+  error.message.startsWith("Limite diario alcanzado");

--- a/src/services/usecases/ingest-status.ts
+++ b/src/services/usecases/ingest-status.ts
@@ -1,0 +1,43 @@
+import { ingestRunRepository } from "@/src/ports/ingest-run-repository";
+import { isoDateTime } from "@/src/domain/types/iso-date-time";
+
+const DEFAULT_DAILY_CAP = 2;
+
+const toStartOfTodayIso = (): isoDateTime => {
+  const now = new Date();
+  const start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 0, 0, 0);
+  return start.toISOString();
+};
+
+export const getDailyIngestCap = () => {
+  const raw = process.env.INGEST_DAILY_CAP?.trim();
+  if (!raw) return DEFAULT_DAILY_CAP;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed)) return DEFAULT_DAILY_CAP;
+  return Math.max(0, Math.floor(parsed));
+};
+
+export type ingestStatus = {
+  used: number;
+  limit: number;
+  remaining: number;
+};
+
+export const createGetIngestStatusUseCase =
+  (dependencies: { ingestRunRepository: ingestRunRepository }) =>
+  async (): Promise<ingestStatus> => {
+    const limit = getDailyIngestCap();
+    const used =
+      limit > 0
+        ? await dependencies.ingestRunRepository.count({
+            since: toStartOfTodayIso(),
+          })
+        : 0;
+    return {
+      used,
+      limit,
+      remaining: Math.max(0, limit - used),
+    };
+  };
+
+export const getStartOfTodayIso = toStartOfTodayIso;

--- a/supabase/migrations/20260204023000_add_ingest_runs.sql
+++ b/supabase/migrations/20260204023000_add_ingest_runs.sql
@@ -1,0 +1,12 @@
+create table if not exists public.ingest_runs (
+  id uuid primary key default gen_random_uuid(),
+  source text,
+  status text not null,
+  created integer not null default 0,
+  updated integer not null default 0,
+  error text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists ingest_runs_created_at_idx
+  on public.ingest_runs (created_at desc);

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -61,3 +61,16 @@ create unique index if not exists jobs_source_external_id_uniq
   on public.jobs(source, external_id);
 create index if not exists jobs_published_at_idx
   on public.jobs(published_at desc);
+
+create table if not exists public.ingest_runs (
+  id uuid primary key default gen_random_uuid(),
+  source text,
+  status text not null,
+  created integer not null default 0,
+  updated integer not null default 0,
+  error text,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists ingest_runs_created_at_idx
+  on public.ingest_runs(created_at desc);


### PR DESCRIPTION
## Summary
- Add daily ingest cap (default 2) enforced server-side.
- Track ingest runs in a new table and expose /api/ingest/status.
- Show ingestion usage (1/2, 2/2) and disable when capped.

## Testing
- Not run (not requested).

Closes #145